### PR TITLE
Fix error when running grunt jshint: ui\Widget.js

### DIFF
--- a/ui/Widget.js
+++ b/ui/Widget.js
@@ -15,7 +15,7 @@ define(['../core/extend', '../core/ext/Properties', '../core/on', '../core/defer
 			for (cnt = 0; cnt < len; cnt += 1) {
 				this.$njsChildWidgets[cnt].destroy();
 			}
-			len = this.$njsEventListenerHandlers.length
+			len = this.$njsEventListenerHandlers.length;
 			this.remove();
 			for (cnt = 0; cnt < len; cnt += 1) {
 				this.$njsEventListenerHandlers[cnt].remove();


### PR DESCRIPTION
Fix error when running `grunt jshint`: 
- File `ui\Widget.js` line 18
- Error `len = this.$njsEventListenerHandlers.length` => `Missing semicolon.`
